### PR TITLE
Update esp32_s3_matrix.yml

### DIFF
--- a/esp32_s3_matrix.yml
+++ b/esp32_s3_matrix.yml
@@ -91,3 +91,46 @@ light:
       - addressable_flicker:
       - addressable_fireworks:
           name: Fireworks
+      - addressable_lambda:
+          name: "Green Tick"
+          update_interval: 5s
+          lambda: |-
+            for (int i = 0; i < it.size(); i++) {
+              it[i] = ESPColor(0, 0, 0);
+            } // Clear display
+
+            std::vector<uint8_t> tick = {
+              7,             // row 0
+              14, 15,        // row 1
+              21, 22,        // row 2
+              24, 28, 29,    // row 3
+              32, 33, 35, 36,// row 4
+              41, 42, 43,    // row 5
+              50             // row 6
+            };
+            for (auto i : tick) {
+              it[i] = ESPColor(0, 255, 0);
+            }
+
+      - addressable_lambda:
+          name: "Red No Entry"
+          update_interval: 5s
+          lambda: |-
+            for (int i = 0; i < it.size(); i++) {
+              it[i] = ESPColor(0, 0, 0);
+            } // Clear display
+
+            // Red no entry
+            std::vector<uint8_t> ring = {
+              2, 3, 4, 5,    // row 0
+              9, 14,         // row 1
+              16, 21, 23,    // row 2
+              24, 28, 31,    // row 3
+              32, 35, 39,    // row 4
+              40, 42, 47,    // row 5
+              49, 54,        // row 6
+              58, 59, 60, 61 // row 7
+            };
+            for (auto i : ring) {
+              it[i] = ESPColor(255, 0, 0);  // Red
+            }

--- a/esp32_s3_matrix.yml
+++ b/esp32_s3_matrix.yml
@@ -99,7 +99,7 @@ light:
               it[i] = ESPColor(0, 0, 0);
             } // Clear display
 
-            std::vector<uint8_t> tick = {
+            static const std::vector<uint8_t> tick = {
               7,             // row 0
               14, 15,        // row 1
               21, 22,        // row 2


### PR DESCRIPTION
This pull request adds two new addressable lambda effects to the `esp32_s3_matrix.yml` configuration file. These effects are designed to display specific patterns on an LED matrix: a green tick and a red "no entry" symbol.

### Added addressable lambda effects:
* **Green Tick Effect**:
  - Displays a green tick pattern on the LED matrix.
  - Clears the display before rendering the tick using a predefined set of LED indices.
  - Updates every 5 seconds.

* **Red No Entry Effect**:
  - Displays a red "no entry" ring pattern on the LED matrix.
  - Clears the display before rendering the ring using a predefined set of LED indices.
  - Updates every 5 seconds.Added availability effects